### PR TITLE
COS-26: Error Handling when Payment API call to Odoo

### DIFF
--- a/models/account_invoice.py
+++ b/models/account_invoice.py
@@ -319,6 +319,7 @@ class AccountInvoice(models.Model):
         self.line_items_handling(invoice)
         invoice.compute_taxes()
         invoice.action_invoice_open()
+        self.response_data.update(invoice_number=invoice.number)
 
     def line_items_handling(self, invoice):
         """ Creates/updates or deletes invoice line
@@ -360,9 +361,9 @@ class AccountInvoice(models.Model):
 
     def update_line(self, line, invoice_line, invoice_id):
         """ Updates invoice lines
-        :param line: dictionary invoice line from input params
-        :param invoice_line: account.invoice.line to update
-        :param invoice_id: relation invoice id
+         :param line: dictionary invoice line from input params
+         :param invoice_line: account.invoice.line to update
+         :param invoice_id: relation invoice id
         """
         line.update(invoice_id=invoice_id)
         if not invoice_line.write(line):
@@ -479,6 +480,7 @@ class AccountInvoice(models.Model):
                                         invoice.journal_id.id)
         refund_invoice.write({'x_civicrm_id': invoice.x_civicrm_id})
         refund_invoice.action_invoice_open()
+        self.response_data.update(creditnote_number=refund_invoice.number)
         refund_invoice.re_reconcile_payment()
 
     @api.multi
@@ -523,6 +525,7 @@ class AccountInvoice(models.Model):
          :return: response in dictionary format
         """
         self.error_handler()
+        self.response_data.update(timestamp=int(time.time()))
         return self.response_data
 
     def error_handler(self):


### PR DESCRIPTION
It returns the following information in its API response:     

1. is_error - 0 when successful and 1 when failed
2. error_log - present when is_error is 1 and should catch the error information
3. contribution_id - the id of the synced contribution record
4. invoice_number - the number of the latest invoice created in Odoo for the corresponding contribution
5. creditnote_number - the number of the latest refund invoice created in Odoo for the corresponding contribution
6. timestamp - the timestamp when the respound is made.

When is_error = 0
![cos-26](https://user-images.githubusercontent.com/36959503/39647609-4fd56ac6-4fe8-11e8-9105-887abd52baa5.gif)

When is_error = 1
![cos-26-2](https://user-images.githubusercontent.com/36959503/39647615-5a522688-4fe8-11e8-96bf-e8a27c077f43.gif)

