### PR TITLE
COS-31: Sync fields and sync information update on payments for CiviCRM synced invoices.

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,3 +2,4 @@
 from . import account_invoice
 from . import civicrm_sync_settings
 from . import res_partner
+from . import account_payment

--- a/models/account_invoice.py
+++ b/models/account_invoice.py
@@ -38,13 +38,6 @@ LOOK_UP_MAP = {
 }
 
 
-class account_payment(models.Model):
-    _inherit = "account.payment"
-
-    x_civicrm_id = fields.Integer(string='Civicrm Id', required=False,
-                                  help='Civicrm Id')
-
-
 class AccountInvoiceLine(models.Model):
     _inherit = "account.invoice.line"
 
@@ -547,3 +540,16 @@ class AccountInvoice(models.Model):
         """
         dt = datetime.strptime(date_time, DATETIME_FORMAT)
         return time.mktime(dt.timetuple())
+
+    @api.multi
+    def assign_outstanding_credit(self, credit_aml_id):
+        """ Override method to update sync status
+         :param credit_aml_id: int Account move line ids
+         :return: bool
+        """
+        res = super(AccountInvoice, self).assign_outstanding_credit(
+            credit_aml_id)
+        if not self.x_civicrm_id:
+            for payment in self.payment_ids:
+                payment.x_sync_status = 'awaiting'
+        return res

--- a/models/account_payment.py
+++ b/models/account_payment.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class account_payment(models.Model):
+    _inherit = "account.payment"
+
+    x_civicrm_id = fields.Integer(string='Civicrm Id', required=False,
+                                  help='Civicrm Id')
+
+    x_sync_status = fields.Selection([
+        ('awaiting', 'Awaiting Sync'),
+        ('synced', 'Synced'),
+        ('failed', 'Sync failed'),
+        (None, 'None'),
+    ], default=None, string='Sync Status',
+        help='When a payment is registered to an invoice whose x_civicrm_id '
+             'is not empty, this field should be set to "Awaiting sync".')
+
+    x_last_retry = fields.Date(string='Last Retry', help='Last Retry')
+    x_retry_count = fields.Integer(string='Retry Count', help='Retry Count')
+    x_error_log = fields.Text(string='Error Log', help='Error Log')
+
+    @api.model
+    def create(self, vals):
+        """  Override method to update sync status
+         :param vals: dictionary values
+         :return: new account_payment object
+        """
+        if not vals.get('x_civicrm_id'):
+            vals.update(x_sync_status='awaiting')
+        return super(account_payment, self).create(vals)


### PR DESCRIPTION
1. The module installs the fields specified in the tables below to the payment model:
    - Sync Status
    - Last Retry
    - Retry Count
    - Error Log

2. If a payment is created/ reconciled against an invoice whose x_civicrm_id is not empty: 
    its "Sync Status" field should be filled with "Awaiting Sync".

![cos-31-correct](https://user-images.githubusercontent.com/36959503/39751221-24eb080e-52c0-11e8-8035-8e6ad1a2f03b.gif)

