### PR TITLE
COS-32: Send multiple error on payment sync by one message when sync is failed.

### DIFF
--- a/data/error_mail_template.xml
+++ b/data/error_mail_template.xml
@@ -4,7 +4,7 @@
 
         <!--Email template -->
         <record id="odoo_sivicrm_sync_error" model="mail.template">
-            <field name="name">Odoo - SiviCRM Sync Error Email</field>
+            <field name="name">Odoo - CiviCRM Sync Error Email</field>
             <field name="email_from">test@test_from.test</field>
             <field name="subject">Odoo - SiviCRM sync error</field>
             <field name="email_to">${user.company_id.error_notice_address}</field>

--- a/data/error_mail_template.xml
+++ b/data/error_mail_template.xml
@@ -8,12 +8,27 @@
             <field name="email_from">test@test_from.test</field>
             <field name="subject">Odoo - SiviCRM sync error</field>
             <field name="email_to">${user.company_id.error_notice_address}</field>
-            <field name="model_id" ref="odoo_civicrm_sync.model_account_payment"/>
+            <field name="model_id" ref="odoo_civicrm_sync.model_payment_sync"/>
             <field name="auto_delete" eval="True"/>
             <field name="body_html"><![CDATA[
-<p>Entity type: Payment</p>
-<p>Entity id: ${object.id}</p>
-<p>Error log: ${object.x_error_log}</p>
+<h2>Odoo CiviCRM Sync Error Report</h2>
+<br>
+<table>
+<tbody>
+<tr>
+<th><p>Entity type</p></th>
+<th><p>   Entity id</p></th>
+<th><p>   Error log</p></th>
+</tr>
+% for p in object.payments:
+<tr>
+<td><p>Payment</p></td>
+<td><p>   ${p.id}</p></td>
+<td><p>   ${p.x_error_log}</p></td>
+</tr>
+% endfor
+</tbody>
+</table>
 ]]></field>
         </record>
     </data>


### PR DESCRIPTION
When ‘Retry Thresholds’ is reached and Sync is failed then error message is sent by email.
When multiple payment sync is failed and reached the ‘Retry Threshold’ then only one message with multiple errors is sent by email.