### PR TITLE
ASE-316: Fix submitting invoice payment error

### DIFF
--- a/models/account_payment.py
+++ b/models/account_payment.py
@@ -39,7 +39,7 @@ class account_payment(models.Model):
         invoices = payment.invoice_ids
         if invoices and len(invoices) > 1:
             return payment
-        invoice = invoices.filtered(lambda invoice: invoice.x_civicrm_ids)
-        if invoice and not payment.x_civicrm_id:
+        invoice = invoices.filtered(lambda invoice: invoice.x_civicrm_id)
+        if invoice and not payment.x_civicrm_ids:
             payment.x_sync_status = 'awaiting'
         return payment


### PR DESCRIPTION
## Problem

when submitting a payment against odoo invoice, the following error will appear : 
```
Error:
Odoo Server Error

odoo_civicrm_sync/models/account_payment.py", line 42, in <lambda>
    invoice = invoices.filtered(lambda invoice: invoice.x_civicrm_ids)
AttributeError: 'account.invoice' object has no attribute 'x_civicrm_ids'
```

## Solution
The issue is caused by this PR 
https://github.com/compucorp/odoo_civicrm_sync/pull/25/files

I replaced the use of x_civicrm_id field for the invoice entity with x_civicrm_ids upon the creation of the payment, but x_civicrm_ids it should be used only for the payment entity and not the inovice entity which is what I corrected in this PR.