### PR TITLE
ASE-316: Fix from and to finincal account mapping to civicrm

### DIFF
--- a/models/payment_sync.py
+++ b/models/payment_sync.py
@@ -191,11 +191,14 @@ class PaymentSync(models.TransientModel):
         debit_lines = payment.move_line_ids.filtered(lambda l: l.debit)
         transactions = []
         for debit_line in debit_lines:
-            transaction = {"credit_account_code": debit_line.account_id.code, "total_amount": debit_line.debit}
+            transaction = {"account_code": debit_line.account_id.code, "total_amount": debit_line.debit}
             transactions.append(transaction)
 
+        credit_lines = payment.move_line_ids.filtered(lambda l: l.credit)
+        first_credit_line_account_code = credit_lines[0].account_id.code
+
         return [
-            {"to_financial_account_name": payment.journal_id.name},
+            {"from_financial_account_code": first_credit_line_account_code},
             {"trxn_date": int(payment_date)},
             {"currency": payment.currency_id.name},
             {"invoice_id": payment_to_invoice.x_civicrm_id},


### PR DESCRIPTION
Related PRs : 
https://github.com/compucorp/uk.co.compucorp.odoosync/pull/47
--------

When syncing a payment from odoo to CiviCRM, the previous field mapping was as following : 

- debit journal item account code on odoo =[to]=> **from_financial_account_id** on civicrm financial transaction entity

- the odoo payment to be synced journal name =[to]=> **to_financial_account_id** on civicrm financial transaction entity (based on the assumption that there is a financial account on civicrm for each journal on odoo were both hold the same name)

But the mapping should be as following (which is fixed in this PR) : 

- debit journal item account code on odoo =[to]=> **to_financial_account_id** on civicrm financial transaction entity (hence there might be in some cases N number of debit journal items and in that case N financial transactions records will be created on civicrm for each debit journal item)

- credit journal item account code on odoo =[to]=> **from_financial_account_id** on civicrm financial transaction entity  (hence that according to the cases we are aware of and our limited accounting knowledge that there couldn't be more than one credit journal item for the same payment so we just pick its accounting code)