### PR TITLE
ASE-316: Ensure that only non-draft payments get synced to civicrm

### DIFF
--- a/models/payment_sync.py
+++ b/models/payment_sync.py
@@ -219,12 +219,14 @@ class PaymentSync(models.TransientModel):
         return convert_map.get(state, state)
 
     def _get_awaiting_payments(self):
-        """ Gets payments from db
+        """ Gets the non draft payments that
+            are awaiting to be synced to CiviCrm
          :return: account_payment models list
         """
         return self.env['account.payment'].search(
             [
                 ('x_sync_status', '=', 'awaiting'),
+                ('state', '!=', 'draft'),
                 ('payment_date', '<=', fields.Date.today())
             ],
         )


### PR DESCRIPTION
This updates the odoo sync payments to civicrm scheduled job so only non draft payments get synced to civicrm.