### PR TITLE
ASE-316: Don't sync cancelled payments

### DIFF
--- a/models/payment_sync.py
+++ b/models/payment_sync.py
@@ -226,7 +226,7 @@ class PaymentSync(models.TransientModel):
         return self.env['account.payment'].search(
             [
                 ('x_sync_status', '=', 'awaiting'),
-                ('state', '!=', 'draft'),
+                ('state', 'not in', ('draft', 'cancelled')),
                 ('payment_date', '<=', fields.Date.today())
             ],
         )


### PR DESCRIPTION
This make sure that not just "Draft" but also "Cancelled" payments do not get synced back to civicrm