### PR TITLE
ASE-316: Ensure that the mapping between odoo payment and civicrm financial transaction is stored correctly

### DIFF
--- a/models/payment_sync.py
+++ b/models/payment_sync.py
@@ -168,7 +168,7 @@ class PaymentSync(models.TransientModel):
         else:
             for transactionElement in result_set.findall('transactions/record'):
                 transactions_id_element = transactionElement.find('id')
-                if transactions_id_element:
+                if transactions_id_element is not None:
                     transactions_id = int(transactions_id_element.text)
                     civi_transaction = self.env['civicrm.financial.transaction']
                     civi_transaction.create({'x_financial_transaction_id': transactions_id, 'payment_id': payment.id})


### PR DESCRIPTION
It seems that sometimes this statement : 

```
if transactions_id_element:
```

might not execute the body of the if statement even if there is an element found which result in the mapping between the payment on odoo and the civicrm financial transaction not to be stored on odoo. I replaced it with more accurate validation which is : 

```
if transactions_id_element is not None:
```

since the find() method will return None if not element was found.