### PR TITLE
ASE-316: Enusre completing payments on civicrm sync data correctly to odoo

### DIFF
--- a/models/account_payment.py
+++ b/models/account_payment.py
@@ -39,6 +39,11 @@ class account_payment(models.Model):
         invoices = payment.invoice_ids
         if invoices and len(invoices) > 1:
             return payment
+
+        if 'x_civicrm_id' in vals:
+            civi_transaction = self.env['civicrm.financial.transaction']
+            civi_transaction.create({'x_financial_transaction_id': vals.get('x_civicrm_id'), 'payment_id': payment.id})
+
         invoice = invoices.filtered(lambda invoice: invoice.x_civicrm_id)
         if invoice and not payment.x_civicrm_ids:
             payment.x_sync_status = 'awaiting'


### PR DESCRIPTION
## Problem

When syncing completed payments from civicrm to odoo, the mapping between the financial transaction and the payment was not get created, which result in the payment to get marked as "awaiting for sync" and for it to get synced again to civicrm and creating duplicate financial transaction.

## Solution

While creating the payment, we now check if it have x_civicrm_id provided from civicrm, if yes then the mapping to the payment will be created which will prevent the payment status from being changed to "awaiting for sync".