### PR TITLE
COS-51: Ensure that payments created by reconciliation get synced to CiviCRM

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -5,3 +5,4 @@ from . import res_partner
 from . import payment_sync
 from . import account_payment
 from . import civicrm_financial_transaction
+from . import account_bank_statement_line

--- a/models/account_bank_statement_line.py
+++ b/models/account_bank_statement_line.py
@@ -32,7 +32,7 @@ class AccountBankStatementLine(models.Model):
     def _get_after_reconciliation_payment_and_invoice(self, data):
         try:
             self.env.cr.execute("""
-            SELECT aml.pa  yment_id, amamlr.account_invoice_id FROM account_move_line AS aml 
+            SELECT aml.payment_id, amamlr.account_invoice_id FROM account_move_line AS aml 
             INNER JOIN  account_invoice_account_move_line_rel as amamlr ON amamlr.account_move_line_id = aml.id 
             WHERE aml.name = %s AND aml.partner_id = %s AND credit > 0 LIMIT 1""",
                                 (data[0]['counterpart_aml_dicts'][0]['name'], data[0]['partner_id']))

--- a/models/account_bank_statement_line.py
+++ b/models/account_bank_statement_line.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = "account.bank.statement.line"
+
+    @api.multi
+    def process_reconciliations(self, data):
+        """ Overrides process_reconciliations method that
+         process reconciled statements. The purpose is to set
+         the payments created by the reconciliation sync status to "awaiting"
+         so they get synced back to CiviCRM instead of being ignored.
+         And since the invoice won't be linked directly to the payment but
+         instead  the move lines, we determine it by checking the move lines
+         that are connected to the payment.
+        """
+        super(AccountBankStatementLine, self).process_reconciliations(data = data)
+        after_reconciliation_data = self._get_after_reconciliation_payment_and_invoice(data)
+        if after_reconciliation_data:
+            payment = after_reconciliation_data['payment']
+            invoice = after_reconciliation_data['invoice']
+            if invoice.x_civicrm_id and not payment.x_civicrm_ids and not payment.x_sync_status:
+                payment.x_sync_status = 'awaiting'
+
+
+    def _get_after_reconciliation_payment_and_invoice(self, data):
+        try:
+            self.env.cr.execute("""
+            SELECT aml.pa  yment_id, amamlr.account_invoice_id FROM account_move_line AS aml 
+            INNER JOIN  account_invoice_account_move_line_rel as amamlr ON amamlr.account_move_line_id = aml.id 
+            WHERE aml.name = %s AND aml.partner_id = %s AND credit > 0 LIMIT 1""",
+                                (data[0]['counterpart_aml_dicts'][0]['name'], data[0]['partner_id']))
+            record = self.env.cr.fetchone()
+            payment = self.env['account.payment'].search([('id', '=', record[0])])
+            invoice = self.env['account.invoice'].search([('id', '=', record[1])])
+            return {"payment" : payment, "invoice" : invoice}
+        except:
+            return None

--- a/models/payment_sync.py
+++ b/models/payment_sync.py
@@ -40,7 +40,8 @@ class PaymentSync(models.TransientModel):
         self._send_error_email(payments)
 
     def _get_reconciled_payment_invoice_id(self, payment_id):
-        self.env.cr.execute("""SELECT aiamlr.account_invoice_id FROM account_payment AS ap 
+        self.env.cr.execute("""
+        SELECT aiamlr.account_invoice_id FROM account_payment AS ap 
         INNER JOIN account_move_line AS aml ON ap.id = aml.payment_id 
         INNER JOIN account_invoice_account_move_line_rel AS aiamlr ON aml.id = aiamlr.account_move_line_id 
         WHERE ap.id = %s and aml.credit > 0 LIMIT 1""",
@@ -198,7 +199,7 @@ class PaymentSync(models.TransientModel):
             payment_to_invoice = max(payment.invoice_ids)
 
         if not payment_to_invoice:
-            connected_invoice_id = self._get_reconciled_payment_invoice(payment.id)
+            connected_invoice_id = self._get_reconciled_payment_invoice_id(payment.id)
             if not connected_invoice_id:
                 raise UserError('No invoice connected to payment was found')
             else:


### PR DESCRIPTION
When you reconcile a bank statement with an invoice then a payment will be created but that payment is not linked to the invoice but rather a move lines are created that show the payment amount and these move lines will be connected to both the payment and the invoice. And in case the invoice was synced by CiviCRM, then the newly created payment by the reconciliation will not be synced back to CiviCRM since the status won't be updated to "awaiting" for sync since the payment is no connected to the invoice.

This PR fixes this issue by updating the payment status at the time of reconciliation if the following conditions are met : 

1- there is a credit move line that is both linked to the invoice and the payment.
2- the linked invoice x_civicrm_id is not Null which means that it is originally synced from CiviCRM.
3- the payment x_civicrm_ids is empty which means the payment is not a one that already synced to CiviCRM.
4- the payment x_sync_status is Null just as an insurance (confirmation) that the payment is not already synced to CiviCRM.

The PR achieve that by overriding AccountBankStatementLine.process_reconciliations() method, calling the parent reconciliation method then doing the above after that.

The other part is when syncing the payments to CiviCRM and since the invoice is not linked directly to the payment, so I changed the code to check if there is any invoice linked by the move lines and use it in case the invoice is not directly linked to the payment, otherwise the payment will be ignored.