### PR TITLE
ASESPRT-140: Fix payments sync to civicrm after for latest odoo 11.0

### DIFF
--- a/models/account_bank_statement_line.py
+++ b/models/account_bank_statement_line.py
@@ -35,7 +35,15 @@ class AccountBankStatementLine(models.Model):
             if data_dict['partner_id']:
                 partner_id = data_dict['partner_id']
             else:
-                partner_id = data_dict['counterpart_aml_dicts'][0]['partner_id']
+                account_move_line_id = data_dict['counterpart_aml_dicts'][0]['counterpart_aml_id']
+                account_move_line = self.env['account.move.line'].search([('id', '=', account_move_line_id)])
+                if account_move_line.partner_id:
+                    partner = account_move_line.partner_id
+                    partner_id = partner.id
+
+                else:
+                    return None
+
             self.env.cr.execute("""
             SELECT aml.payment_id, amamlr.account_invoice_id FROM account_move_line AS aml 
             INNER JOIN  account_invoice_account_move_line_rel as amamlr ON amamlr.account_move_line_id = aml.id 


### PR DESCRIPTION
## The Problem

1- Sync a pending payment from CiviCRM to Odoo (a new open invoice will be created)
2- Create a new bank statement with the same invoice amount without selecting a partner during the creation

![2019-10-07 14_24_19-Calendar](https://user-images.githubusercontent.com/6275540/66307878-878c4e80-e8fd-11e9-9f7e-af91a8730ad4.png)


3- Reconcile the bank statement and select the invoice that was created in step 1. The invoice status will be changed to Paid and a payment with the same amount will be created.

4- Try to sync the payment back to CiviCRM by running the "Odoo -> Civi Payment sync" scheduled job, The payment should be synced to CiviCRM and the CiviCRM contribution status should change from Pending to -> Completed but this ain't happening.


This issue started to happen after we upgraded to the latest odoo v11.0, it appears that in the latest version and in case no partner was selected during the creation of the bank statement, then the data passed to ```process_reconciliations()``` method changed something similar to : 

```
{'partner_id': False, 'counterpart_aml_dicts': [{'name': 'PUB/2019/0014: CIVI 162', 'debit': 0, 'credit': 20, 'move_id': 11533, 'partner_id': 23936, 'statement_line_id': 2322, 'account_id': 19, 'payment_id': 2079, 'currency_id': 3, 'amount_currency': -20.0, 'date_maturity': '2019-10-07'}], 'payment_aml_ids': [], 'new_aml_dicts': []}
```

to  something similar to : 

```
[{'partner_id': False, 'counterpart_aml_dicts': [{'debit': 0, 'counterpart_aml_id': 55068, 'name': 'PUB/2019/0290: CIVI 29651', 'credit': 53.5}], 'payment_aml_ids': [], 'new_aml_dicts': []}]
```

Mainly the partner_id inside ```counterpart_aml_dicts``` list is no longer exist, so this line is causing the issue  : 

```
partner_id = data_dict['counterpart_aml_dicts'][0]['partner_id']
```



## The Solution

Since the new data passed to ```process_reconciliations()```  method contain the move line id `counterpart_aml_id`, I used it instead to fetch the partner Id .