### PR TITLE
ASESPRT-225: Fix syncing refunded/canceled contributions

### DIFF
--- a/models/account_invoice.py
+++ b/models/account_invoice.py
@@ -41,11 +41,6 @@ LOOK_UP_MAP = {
                                 'x_civicrm_id'),
 }
 
-DUPLICATE_MAP = {
-    'refund_date_invoice': 'date'
-}
-
-
 class AccountInvoiceLine(models.Model):
     _inherit = "account.invoice.line"
 
@@ -168,7 +163,7 @@ class AccountInvoice(models.Model):
                 'filter_refund': ParamType(str, False, None, 'refund', 100),
                 'description': ParamType(str, False, None, '', 100),
                 'date': ParamType(str, False, None, None, 100),
-                'date_invoice': ParamType(str, False, self._duplicate_field, 0, 101),
+                'date_invoice':  ParamType(str, False, None, None, 100),
             },
         }
         self._model_name = ''
@@ -218,15 +213,6 @@ class AccountInvoice(models.Model):
 
         if value is not None and param_type.convert_method:
             param_type.convert_method(key=key, value=value, vals=vals)
-
-    def _duplicate_field(self, **kwargs):
-        """ Copy value from another field according to the DUPLICATE_MAP
-         :param kwargs: dictionary with value for duplicate
-        """
-        key = kwargs.get('key')
-        vals = kwargs.get('vals')
-        duplicate_fild_name = DUPLICATE_MAP.get('{}_{}'.format(self._model_name, key))
-        vals[key] = vals.get(duplicate_fild_name)
 
     def lookup_id(self, **kwargs):
         """ Lookups the ODOO ids


### PR DESCRIPTION
## Before

Refunded or cancelled contributions are not getting synced and the following error appears in the log : 

```
Wrong CiviCRM request - invalid "date_invoice" parameter date :type expected
```

The issue happened after my last ASESPRT-225 fix in which I changed the invoice related fields passed from CiviCRM from timestamps (validated as integers on odoo) to an actual date string and once of these fields was the refund entity date_invoice field on odoo. 

Now there were two issues with the original code related to this field which are  : 

1- the code was always trying to insert the value 0 for this field instead of an actual date, and since the date is validated as an integer no error was actually thrown and thus the field will be sync, and since this field is not allowed to be empty, odoo core code default it to today date.

2- according to this document : https://compucorp.atlassian.net/wiki/spaces/PS/pages/270237795/QA+-+Odoo+CiviCRM+Sync

this field should be mapped to following civicrm field : `civicrm_financial_trxn.trxn_date` and not to the CiviCRM receive date, but the original code was actually trying to the later (though as explained in the previous issue, it was even failing at that).


Now what happened in my previous ASESPRT-225 fix is that I changed the field to a date string, but since the value 0 was actually getting passed to it, it was failing to validate it and thus the error above appear.

## After

The two issues were fixed by updating the related CiviCRM module in this PR : https://github.com/compucorp/uk.co.compucorp.odoosync/pull/49

so it push the date_invoice as it is supposed to be (which is  `civicrm_financial_trxn.trxn_date` value), and here I updated the module so it accept the passed value directly instead of trying to get it from   the rest of the related invoice data. 
